### PR TITLE
Fix compatibility with shim 15.4 (ubuntu shim-signed 1.40.7+15.4-0ubu…

### DIFF
--- a/Src/Efi/Lib/Pkcs7Verify.c
+++ b/Src/Efi/Lib/Pkcs7Verify.c
@@ -137,12 +137,12 @@ InitializePkcs7(VOID)
 	if (EFI_ERROR(Status))
 		return Status;
 
-	EFI_SIGNATURE_LIST *MokListRT = NULL;
-	UINTN MokListRTSize = 0;
+	EFI_SIGNATURE_LIST *MokList = NULL;
+	UINTN MokListSize = 0;
 
-	Status = EfiSecurityPolicyLoad(L"MokListRT", &MokListRT, &MokListRTSize);
+	Status = EfiSecurityPolicyLoad(L"MokList", &MokList, &MokListSize);
 	if (EFI_ERROR(Status) && Status != EFI_NOT_FOUND)
-		goto ErrorOnLoadMokListRT;
+		goto ErrorOnLoadMokList;
 
 	EFI_SIGNATURE_LIST *Dbx = NULL;
 	UINTN DbxSize = 0;
@@ -158,8 +158,8 @@ InitializePkcs7(VOID)
 	if (EFI_ERROR(Status) && Status != EFI_NOT_FOUND)
 		goto ErrorOnLoadMokListXRT;
 
-	Status = MergeSignatureList(&AllowedDb, Db, DbSize, MokListRT,
-				    MokListRTSize);
+	Status = MergeSignatureList(&AllowedDb, Db, DbSize, MokList,
+				    MokListSize);
 	if (EFI_ERROR(Status)) {
 		EfiConsolePrintError(L"Failed to merge the allowed "
 				     L"database (err: 0x%x)\n");
@@ -190,9 +190,9 @@ ErrorOnLoadMokListXRT:
 	EfiMemoryFree(Dbx);
 
 ErrorOnLoadDbx:
-	EfiMemoryFree(MokListRT);
+	EfiMemoryFree(MokList);
 
-ErrorOnLoadMokListRT:
+ErrorOnLoadMokList:
 	EfiMemoryFree(Db);
 
 	return Status;

--- a/Src/Efi/Lib/SecurityPolicy.c
+++ b/Src/Efi/Lib/SecurityPolicy.c
@@ -215,6 +215,8 @@ EfiSecurityPolicyLoad(CONST CHAR16 *Name, EFI_SIGNATURE_LIST **SignatureList,
 		else
 			Ignored = TRUE;
 	} else if (!StrCmp(Name, L"MokListRT") ||
+		   !StrCmp(Name, L"MokList") ||
+		   !StrCmp(Name, L"MokListX") ||
 		   !StrCmp(Name, L"MokListXRT")) {
 		if (UefiSecureBootEnabled == TRUE &&
 		    MokSecureBootEnabled == TRUE)


### PR DESCRIPTION
…ntu9)

MokListRT mirroring has been changed between shim 15 and 15.4

This patch fixes problem where PKCS7 signature verification doesn't work after shim upgrade because PKCS7 signature verification function got invalid cert data.